### PR TITLE
Fix proguard issue with windows paths

### DIFF
--- a/plugin/src/main/kotlin/io/specmatic/gradle/exec/ConfigureExecTaskPlugin.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/exec/ConfigureExecTaskPlugin.kt
@@ -81,7 +81,7 @@ fun shellEscape(word: String): String {
     if (len == 0) {
         // Empty string is a special case: needs to be quoted to ensure that it gets
         // treated as a separate argument.
-        return "''"
+        return "\"\""
     }
     for (ii in 0 until len) {
         val c = word[ii]
@@ -89,7 +89,7 @@ fun shellEscape(word: String): String {
         // any unsafe characters.
         if (!Character.isLetterOrDigit(c) && SAFE_PUNCTUATION.indexOf(c) == -1) {
             // replace() actually means "replace all".
-            return "'" + word.replace("'", "'\\''") + "'"
+            return "\"" + word.replace("\"", "\"\"").replace("\\", "\\\\") + "\""
         }
     }
     return word

--- a/plugin/src/main/kotlin/io/specmatic/gradle/jar/obfuscate/ProguardTask.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/jar/obfuscate/ProguardTask.kt
@@ -96,9 +96,9 @@ abstract class ProguardTask @Inject constructor(
         appendArgsToFile("-injars", inputJar!!.absolutePath)
         appendArgsToFile("-outjars", outputJar!!.absolutePath)
 
-        appendArgsToFile("-printseeds", "${getProguardOutputDir()}/seeds.txt")
-        appendArgsToFile("-printconfiguration", "${getProguardOutputDir()}/proguard.cfg")
-        appendArgsToFile("-dump", "${getProguardOutputDir()}/proguard.dump.txt")
+        appendArgsToFile("-printseeds", "${getProguardOutputDir().resolve("seeds.txt")}")
+        appendArgsToFile("-printconfiguration", "${getProguardOutputDir().resolve("proguard.cfg")}")
+        appendArgsToFile("-dump", "${getProguardOutputDir().resolve("proguard.dump.txt")}")
         appendArgsToFile("-whyareyoukeeping", "class io.specmatic.** { *; }")
         appendArgsToFile("-dontoptimize")
         appendArgsToFile("-keepattributes", "!LocalVariableTable, !LocalVariableTypeTable")


### PR DESCRIPTION
- Use .resolve when generating arguments for the ProGuardTask
- Escape the Windows file path separator in shellEscape