### PR TITLE
Add ability to externalize version replacements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ plugin will take care of the rest. Batteries included. Just provide the credenti
         kotlinApiVersion = KotlinVersion.KOTLIN_1_9
         // List of sample projects that need validation before release, and bumping post release
         downstreamDependentProjects = listOf("project1", "project2")
+   
+        // replace certain dependencies with other dependencies
+        versionReplacements = mapOf(
+            "org.example.foo:deprecated" to "org.example.foo:shiny-thing:1.2.3"
+        )    
     
         // Publish this to some repositories. Can be invoked multiple times
         publishTo("internalRepo", "https://internal.repo.url/repository/maven-releases/")

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -22,9 +22,11 @@ dependencies {
     implementation("org.kohsuke:github-api:1.327")
     implementation("org.cyclonedx.bom:org.cyclonedx.bom.gradle.plugin:2.2.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.3")
+
     testImplementation("org.apache.maven:maven-model:3.9.9")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.assertj:assertj-core:3.27.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.12.2")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/extensions/SpecmaticGradleExtension.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/extensions/SpecmaticGradleExtension.kt
@@ -25,6 +25,7 @@ open class SpecmaticGradleExtension {
     internal val publishTo = mutableListOf<PublishTarget>()
     internal val licenseData = mutableListOf<ModuleLicenseData>()
     internal val projectConfigurations: MutableMap<Project, DistributionFlavor> = mutableMapOf()
+    var versionReplacements = mutableMapOf<String, String>()
 
     fun publishToMavenCentral() {
         publishTo.add(MavenCentral())

--- a/plugin/src/main/kotlin/io/specmatic/gradle/versions/ForceVersionConstraintsPlugin.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/versions/ForceVersionConstraintsPlugin.kt
@@ -1,28 +1,35 @@
 package io.specmatic.gradle.versions
 
 import io.specmatic.gradle.license.pluginInfo
+import io.specmatic.gradle.specmaticExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+
 class ForceVersionConstraintsPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.configurations.all {
-            resolutionStrategy.eachDependency {
+        target.afterEvaluate {
+            val versionReplacements = target.specmaticExtension().versionReplacements
 
-                val replacements = mapOf(
-                    "javax.validation:validation-api" to "jakarta.validation:jakarta.validation-api:3.1.1",
-                    "dk.brics.automaton:automaton" to "dk.brics:automaton:1.12-4"
-                )
-
-                replacements.forEach { (source, replacement) ->
-                    val (sourceGroup, sourceName) = source.split(":")
-                    if (requested.group == sourceGroup && requested.name == sourceName) {
-                        target.pluginInfo("Replacing $source with $replacement")
-                        useTarget(replacement)
-                        because("Overridden by plugin")
+            target.configurations.all {
+                resolutionStrategy.eachDependency {
+                    (REPLACEMENTS + versionReplacements).forEach { (source, replacement) ->
+                        val (sourceGroup, sourceName) = source.split(":")
+                        if (requested.group == sourceGroup && requested.name == sourceName) {
+                            target.pluginInfo("Replacing $source with $replacement")
+                            useTarget(replacement)
+                            because("Overridden by plugin")
+                        }
                     }
                 }
             }
         }
+    }
+
+    companion object {
+        val REPLACEMENTS = mapOf(
+            "javax.validation:validation-api" to "jakarta.validation:jakarta.validation-api:3.1.1",
+            "dk.brics.automaton:automaton" to "dk.brics:automaton:1.12-4",
+        )
     }
 }

--- a/plugin/src/test/kotlin/io/specmatic/gradle/versions/ForceVersionConstraintsPluginTest.kt
+++ b/plugin/src/test/kotlin/io/specmatic/gradle/versions/ForceVersionConstraintsPluginTest.kt
@@ -1,0 +1,44 @@
+package io.specmatic.gradle.versions
+
+import io.specmatic.gradle.SpecmaticGradlePlugin
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class ForceVersionConstraintsPluginTest {
+    @ParameterizedTest
+    @MethodSource("provideStringsForIsBlank")
+    fun `it should force dependencies correctly`(
+        inputDependency: String,
+        expectedDependency: String
+    ) {
+        val project: Project = ProjectBuilder.builder().build()
+        project.group = "org.example"
+        project.version = "1.2.3"
+
+        project.plugins.apply("java")
+        project.plugins.apply(SpecmaticGradlePlugin::class.java)
+        project.repositories.mavenCentral()
+
+        val dependencyConfiguration = project.configurations.create("testConfiguration")
+        dependencyConfiguration.dependencies.add(project.dependencies.create(inputDependency))
+
+        project.evaluationDependsOn(":")
+        dependencyConfiguration.resolve()
+
+        val resolvedDependency = dependencyConfiguration.resolvedConfiguration.firstLevelModuleDependencies.first()
+        assertThat(resolvedDependency.getName()).isEqualTo(expectedDependency)
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideStringsForIsBlank(): List<Arguments?> {
+            return ForceVersionConstraintsPlugin.REPLACEMENTS.map { (k, v) ->
+                Arguments.of(k, v)
+            }
+        }
+    }
+}


### PR DESCRIPTION
```kotlin
specmatic {
  versionReplacements = mapOf(
    "org.example.foo:deprecated" to "org.example.foo:shiny-thing:1.2.3"
  )
}
```