### PR TITLE
Update validateDownstreamProjectTask to publish subprojects

### DIFF
--- a/plugin/src/main/kotlin/io/specmatic/gradle/downstreamprojects/DownstreamProjectIntegrationPlugin.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/downstreamprojects/DownstreamProjectIntegrationPlugin.kt
@@ -135,8 +135,12 @@ private fun Project.fetchLibsInProjectTask(
 private fun Project.validateDownstreamProjectTask(
     eachRepo: String, cloneRepoIfNotExists: TaskProvider<out Task>
 ): TaskProvider<GradleBuild?> = tasks.register("validate-$eachRepo", GradleBuild::class.java) {
-    dependsOn("publishAllPublicationsToStagingRepository")
-    dependsOn("publishToMavenLocal")
+
+    subprojects.forEach { subproject ->
+        dependsOn("${subproject.path}:publishAllPublicationsToStagingRepository")
+        dependsOn("${subproject.path}:publishToMavenLocal")
+    }
+
     dependsOn(cloneRepoIfNotExists)
 
     dir = getDownstreamProjectDir(eachRepo)


### PR DESCRIPTION
This change ensures that all subprojects publish their artifacts to both the staging repository and the local Maven repository before running downstream validation tasks. This guarantees that the downstream projects have access to the latest artifacts during validation.