### PR TITLE
Fix task dependencies of `vulnScanJar` tasks.

### DIFF
--- a/plugin/src/main/kotlin/io/specmatic/gradle/vuln/RootFSVulnScanTask.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/vuln/RootFSVulnScanTask.kt
@@ -3,6 +3,8 @@ package io.specmatic.gradle.vuln
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.jvm.tasks.Jar
+import org.gradle.plugins.signing.Sign
 import org.gradle.process.ExecOperations
 import java.io.File
 import javax.inject.Inject
@@ -22,6 +24,8 @@ internal fun Project.createJarVulnScanTask() {
 
     val scanTask = tasks.register("${scanTaskName}Scan", RootFSVulnScanTask::class.java) {
         dependsOn("assemble")
+        dependsOn(project.tasks.withType(Jar::class.java))
+        dependsOn(project.tasks.withType(Sign::class.java))
 
         trivyHomeDir.set(trivyHomeDir())
         inputDir.set(project.layout.buildDirectory.file("libs").get().asFile)


### PR DESCRIPTION
We basically do a trivy scan on the `build/libs` dir. However several
tasks output to the `build/libs` dir including `jar` and `sign` tasks.
We need to explicitly depend on those tasks, if we want to scan the `lib`
directory.
