### PR TITLE
fix(release): assert for snapshots after version bump

### DIFF
--- a/plugin/src/main/kotlin/io/specmatic/gradle/release/PreReleaseCheck.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/release/PreReleaseCheck.kt
@@ -1,8 +1,6 @@
 package io.specmatic.gradle.release
 
-import io.specmatic.gradle.license.pluginWarn
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -16,8 +14,6 @@ abstract class PreReleaseCheck : DefaultTask() {
 
     @TaskAction
     fun release() {
-        assertNoSnapshotDependencies()
-
         GitOperations(rootDir.get(), project.properties, logger).apply {
             assertMainBranch()
             assertRepoNotDirty()
@@ -25,29 +21,5 @@ abstract class PreReleaseCheck : DefaultTask() {
         }
 
     }
-
-    private fun assertNoSnapshotDependencies() {
-        if (project.hasProperty("allowSnapshotDependencies") && project.property("allowSnapshotDependencies") == "true") {
-            project.pluginWarn("Skipping snapshot dependency check as per user request.")
-            return
-        }
-        project.allprojects.forEach { project ->
-            val matchingDependencies = (project.configurations + project.buildscript.configurations).flatMap { cfg ->
-                cfg.dependencies.matching { dep ->
-                    dep.version?.contains("SNAPSHOT") == true
-                }
-            }
-
-            if (matchingDependencies.isNotEmpty()) {
-                throw GradleException(
-                    "There are dependencies with SNAPSHOT versions:\n" + matchingDependencies.joinToString(
-                        separator = "\n"
-                    ) { "- ${it.group}:${it.name}:${it.version}" } + "\nPlease remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.")
-            } else {
-                project.pluginWarn("No SNAPSHOT dependencies found.")
-            }
-        }
-    }
-
 
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependencies.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependencies.kt
@@ -1,0 +1,46 @@
+package io.specmatic.gradle.release
+
+import io.specmatic.gradle.license.pluginWarn
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+
+abstract class ValidateSnapshotDependencies : DefaultTask() {
+
+    @TaskAction
+    fun assertNoSnapshotDependencies() {
+        val allowSnapshotDependencies =
+            project.hasProperty("allowSnapshotDependencies") && project.property("allowSnapshotDependencies") == "true"
+
+        val projectToSnapshotDependencies = project.allprojects.associateWith { project ->
+            (project.configurations + project.buildscript.configurations).flatMap { cfg ->
+                cfg.dependencies.matching { dep ->
+                    dep.version?.contains("SNAPSHOT") == true
+                }
+            }
+        }
+
+        if (projectToSnapshotDependencies.isNotEmpty()) {
+            val allPrettyPrintedDependencies =
+                projectToSnapshotDependencies.filterValues { it.isNotEmpty() }.map { (project, matchingDependencies) ->
+                    "Project $project uses dependencies with SNAPSHOT versions:\n" + matchingDependencies.joinToString(
+                        separator = "\n"
+                    ) { "- ${it.group}:${it.name}:${it.version}" }
+                }.joinToString(separator = "\n\n")
+
+            if (allPrettyPrintedDependencies.isNotEmpty()) {
+                val message =
+                    "The following projects have dependencies with SNAPSHOT versions:\n\n$allPrettyPrintedDependencies"
+                if (allowSnapshotDependencies) {
+                    project.pluginWarn(message)
+                } else {
+                    throw GradleException("$message\nPlease remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.")
+                }
+            } else {
+                project.pluginWarn("No SNAPSHOT dependencies found.")
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
doing this before the version bump detects any inter-project dependencies
as having snapshots
