### PR TITLE
feat(docker): generate Dockerfile dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,12 @@ projects.
     
             // Create a docker build/publish task. Pass any optional args to the docker build task. 
             // The `--build-arg VERSION` is already passed as a default 
-            dockerBuild("--extra", "--docker", "--args")
+            dockerBuild {
+                // optional, uses the project name by default
+                imageName = "foo"
+                // any extra docker build args
+                extraDockerArgs = listOf("...")
+            }
     
             // Obfuscation is enabled by default, but you may pass additional proguard args https://www.guardsquare.com/manual/configuration/usage
             obfuscate("-some-arg")

--- a/plugin/src/functionalTest/kotlin/io/specmatic/gradle/features/CommercialLibraryFeatureTest.kt
+++ b/plugin/src/functionalTest/kotlin/io/specmatic/gradle/features/CommercialLibraryFeatureTest.kt
@@ -1,8 +1,7 @@
 package io.specmatic.gradle.features
 
 import io.specmatic.gradle.AbstractFunctionalTest
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/plugin/src/functionalTest/kotlin/io/specmatic/gradle/features/OSSApplicationAndLibraryFeatureTest.kt
+++ b/plugin/src/functionalTest/kotlin/io/specmatic/gradle/features/OSSApplicationAndLibraryFeatureTest.kt
@@ -4,7 +4,7 @@ import io.specmatic.gradle.AbstractFunctionalTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
-import kotlin.test.Test
+import org.junit.jupiter.api.Test
 
 class OSSApplicationAndLibraryFeatureTest : AbstractFunctionalTest() {
     @Nested
@@ -31,6 +31,7 @@ class OSSApplicationAndLibraryFeatureTest : AbstractFunctionalTest() {
                     specmatic {
                         withOSSApplicationLibrary(rootProject) {
                             mainClass = "io.specmatic.example.Main"
+                            dockerBuild()
                         }
                     }
                     
@@ -74,6 +75,23 @@ class OSSApplicationAndLibraryFeatureTest : AbstractFunctionalTest() {
                 "io.specmatic.example.Main"
             )
         }
+
+        @Test
+        fun `it should create docker templates`() {
+            runWithSuccess("dockerBuild", "createDockerFiles")
+
+            assertThat(projectDir.resolve("build/Dockerfile").exists()).isTrue
+            assertThat(projectDir.resolve("build/Dockerfile").readText().lines())
+                .contains("ADD libs/example-project-1.2.3-all-unobfuscated.jar /usr/local/share/example-project.jar")
+                .contains("ADD example-project /usr/local/bin/example-project")
+                .contains("""ENTRYPOINT ["/usr/local/bin/example-project"]""")
+
+            assertThat(projectDir.resolve("build/example-project").exists()).isTrue
+            assertThat(projectDir.resolve("build/example-project").readText().lines())
+                .contains("""#!/usr/bin/env bash""")
+                .contains("""exec java ${'$'}JAVA_OPTS -jar /usr/local/share/example-project.jar "${'$'}@"""")
+        }
+
     }
 
     @Nested
@@ -186,6 +204,9 @@ class OSSApplicationAndLibraryFeatureTest : AbstractFunctionalTest() {
                         
                         withOSSApplicationLibrary(project("executable")) {
                             mainClass = "io.specmatic.example.executable.Main"
+                            dockerBuild {
+                                imageName = "specmatic-foo"
+                            }
                         }
                     }
                     
@@ -245,6 +266,22 @@ class OSSApplicationAndLibraryFeatureTest : AbstractFunctionalTest() {
             assertThat(mainClass("io.specmatic.example:executable-all:1.2.3")).isEqualTo(
                 "io.specmatic.example.executable.Main"
             )
+        }
+
+        @Test
+        fun `it should create docker templates`() {
+            runWithSuccess("dockerBuild", "createDockerFiles")
+
+            assertThat(projectDir.resolve("executable/build/Dockerfile").exists()).isTrue
+            assertThat(projectDir.resolve("executable/build/Dockerfile").readText().lines())
+                .contains("ADD libs/executable-1.2.3-all-unobfuscated.jar /usr/local/share/specmatic-foo.jar")
+                .contains("ADD specmatic-foo /usr/local/bin/specmatic-foo")
+                .contains("""ENTRYPOINT ["/usr/local/bin/specmatic-foo"]""")
+
+            assertThat(projectDir.resolve("executable/build/specmatic-foo").exists()).isTrue
+            assertThat(projectDir.resolve("executable/build/specmatic-foo").readText().lines())
+                .contains("""#!/usr/bin/env bash""")
+                .contains("""exec java ${'$'}JAVA_OPTS -jar /usr/local/share/specmatic-foo.jar "${'$'}@"""")
         }
     }
 

--- a/plugin/src/main/kotlin/io/specmatic/gradle/extensions/SpecmaticGradleExtension.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/extensions/SpecmaticGradleExtension.kt
@@ -26,7 +26,7 @@ open class SpecmaticGradleExtension {
     var kotlinApiVersion: KotlinVersion = KotlinVersion.KOTLIN_1_9
     internal val publishTo = mutableListOf<PublishTarget>()
     internal val licenseData = mutableListOf<ModuleLicenseData>()
-    internal val projectConfigurations: MutableMap<Project, DistributionFlavor> = mutableMapOf()
+    internal val projectConfigurations: MutableMap<Project, BaseDistribution> = mutableMapOf()
     var versionReplacements = mutableMapOf<String, String>()
 
     fun publishToMavenCentral() {

--- a/plugin/src/main/kotlin/io/specmatic/gradle/features/BaseDistribution.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/features/BaseDistribution.kt
@@ -13,6 +13,7 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.publish.tasks.GenerateModuleMetadata
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.exclude
 import org.gradle.plugins.signing.Sign
@@ -88,12 +89,8 @@ abstract class BaseDistribution(protected val project: Project) : DistributionFl
         githubRelease = GithubReleaseConfig().apply(block)
     }
 
-    protected open fun dockerBuild(vararg dockerBuildArgs: String?) {
-        this.project.registerDockerTasks(null, *dockerBuildArgs)
-    }
-
-    protected open fun dockerBuild(imageName: String?, vararg dockerBuildArgs: String?) {
-        this.project.registerDockerTasks(imageName, *dockerBuildArgs)
+    protected open fun dockerBuild(block: DockerBuildConfig.() -> Unit) {
+        this.project.registerDockerTasks(DockerBuildConfig().apply(block))
     }
 
     protected fun setupLogging() {

--- a/plugin/src/main/kotlin/io/specmatic/gradle/features/CommercialApplicationAndLibraryFeature.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/features/CommercialApplicationAndLibraryFeature.kt
@@ -51,11 +51,10 @@ class CommercialApplicationAndLibraryFeature(project: Project) : ShadowingFeatur
         super.githubRelease(block)
     }
 
-    override fun dockerBuild(vararg dockerBuildArgs: String?) {
-        super.dockerBuild(*dockerBuildArgs)
-    }
-
-    override fun dockerBuild(imageName: String?, vararg dockerBuildArgs: String?) {
-        super.dockerBuild(imageName = imageName, *dockerBuildArgs)
+    override fun dockerBuild(block: DockerBuildConfig.() -> Unit) {
+        super.dockerBuild {
+            apply { block() }
+            mainJarTaskName = SHADOW_OBFUSCATED_JAR
+        }
     }
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/features/CommercialApplicationFeature.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/features/CommercialApplicationFeature.kt
@@ -47,11 +47,10 @@ class CommercialApplicationFeature(project: Project) : ApplicationFeature, Shado
         super.githubRelease(block)
     }
 
-    override fun dockerBuild(vararg dockerBuildArgs: String?) {
-        super.dockerBuild(*dockerBuildArgs)
-    }
-
-    override fun dockerBuild(imageName: String?, vararg dockerBuildArgs: String?) {
-        super.dockerBuild(imageName = imageName, *dockerBuildArgs)
+    override fun dockerBuild(block: DockerBuildConfig.() -> Unit) {
+        super.dockerBuild {
+            apply { block() }
+            mainJarTaskName = SHADOW_OBFUSCATED_JAR
+        }
     }
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/features/DockerBuildFeature.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/features/DockerBuildFeature.kt
@@ -1,6 +1,20 @@
 package io.specmatic.gradle.features
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Project
+
 interface DockerBuildFeature {
-    fun dockerBuild(vararg dockerBuildArgs: String?)
-    fun dockerBuild(imageName: String? = null, vararg dockerBuildArgs: String?)
+    fun dockerBuild(block: DockerBuildConfig.() -> Unit = {})
 }
+
+/**
+ * Either specify a jar, or a dockerfile must be present in the root project
+ */
+data class DockerBuildConfig(
+    internal var mainJarTaskName: String? = null,
+    var imageName: String? = null,
+    var extraDockerArgs: MutableList<String> = mutableListOf(),
+)
+
+internal fun Project.mainJar(mainJarTaskName: String) =
+    this.tasks.named(mainJarTaskName, ShadowJar::class.java).get().archiveFile.get().asFile

--- a/plugin/src/main/kotlin/io/specmatic/gradle/features/OSSApplicationAndLibraryFeature.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/features/OSSApplicationAndLibraryFeature.kt
@@ -25,6 +25,7 @@ open class OSSApplicationAndLibraryFeature(project: Project) : ApplicationFeatur
         project.plugins.withType(JavaPlugin::class.java) {
             project.forceJavadocAndSourcesJars()
             val unobfuscatedShadowJarTask = project.createUnobfuscatedShadowJar(shadowActions, shadowPrefix, true)
+
             project.plugins.withType(MavenPublishPlugin::class.java) {
 
                 project.createUnobfuscatedJarPublication(
@@ -59,11 +60,10 @@ open class OSSApplicationAndLibraryFeature(project: Project) : ApplicationFeatur
         super.githubRelease(block)
     }
 
-    override fun dockerBuild(vararg dockerBuildArgs: String?) {
-        super.dockerBuild(*dockerBuildArgs)
-    }
-
-    override fun dockerBuild(imageName: String?, vararg dockerBuildArgs: String?) {
-        super.dockerBuild(imageName = imageName, *dockerBuildArgs)
+    override fun dockerBuild(block: DockerBuildConfig.() -> Unit) {
+        super.dockerBuild {
+            apply { block() }
+            mainJarTaskName = "unobfuscatedShadowJar"
+        }
     }
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/features/OSSApplicationFeature.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/features/OSSApplicationFeature.kt
@@ -25,6 +25,7 @@ open class OSSApplicationFeature(project: Project) : ApplicationFeature, DockerB
         project.plugins.withType(JavaPlugin::class.java) {
             project.forceJavadocAndSourcesJars()
             val unobfuscatedShadowJarTask = project.createUnobfuscatedShadowJar(shadowActions, shadowPrefix, true)
+
             project.plugins.withType(MavenPublishPlugin::class.java) {
                 project.createShadowedUnobfuscatedJarPublication(
                     unobfuscatedShadowJarTask,
@@ -53,11 +54,10 @@ open class OSSApplicationFeature(project: Project) : ApplicationFeature, DockerB
         super.githubRelease(block)
     }
 
-    override fun dockerBuild(vararg dockerBuildArgs: String?) {
-        super.dockerBuild(*dockerBuildArgs)
-    }
-
-    override fun dockerBuild(imageName: String?, vararg dockerBuildArgs: String?) {
-        super.dockerBuild(imageName = imageName, *dockerBuildArgs)
+    override fun dockerBuild(block: DockerBuildConfig.() -> Unit) {
+        super.dockerBuild {
+            apply { block() }
+            mainJarTaskName = "unobfuscatedShadowJar"
+        }
     }
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/jar/publishing/ProjectShadowingExt.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/jar/publishing/ProjectShadowingExt.kt
@@ -21,7 +21,7 @@ import org.gradle.jvm.tasks.Jar
 import java.io.File
 import java.util.jar.JarFile
 
-private const val SHADOW_OBFUSCATED_JAR = "shadowObfuscatedJar"
+internal val SHADOW_OBFUSCATED_JAR = "shadowObfuscatedJar"
 
 internal fun Project.createUnobfuscatedShadowJar(
     shadowActions: MutableList<Action<ShadowJar>>, shadowPrefix: String, isApplication: Boolean

--- a/plugin/src/main/resources/Dockerfile
+++ b/plugin/src/main/resources/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.21
+
+WORKDIR /usr/src/app
+
+# Install OpenJDK 17, git, and curl in a single RUN command
+RUN apk add --no-cache openjdk17-jre git curl bash && \
+    rm -rf /var/cache/apk/*
+
+SHELL ["/bin/bash", "-c"]
+
+ADD %SOURCE_JAR_PATH% %TARGET_JAR_PATH%
+ADD %IMAGE_NAME% /usr/local/bin/%IMAGE_NAME%
+
+ENTRYPOINT ["/usr/local/bin/%IMAGE_NAME%"]

--- a/plugin/src/main/resources/specmatic.sh.template
+++ b/plugin/src/main/resources/specmatic.sh.template
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec java $JAVA_OPTS -jar %TARGET_JAR_PATH% "$@"


### PR DESCRIPTION
- Added an (internal) `createDockerFile` task to generate a Dockerfile
  from a classpath template (`Dockerfile.template`)
- Integrated generated Dockerfile into `dockerBuild` and
  `dockerBuildxPublish` tasks
- Dynamically resolve the main JAR using `mainJarTask` from each
  distribution type
- Refactored image metadata and tagging logic for clarity and
  reusability
- Introduced `Dockerfile.template` for consistent image builds
