### PR TITLE
disable obfuscation of enums, jpa, spring beans, and public interface method param names

### DIFF
--- a/plugin/src/main/kotlin/io/specmatic/gradle/jar/obfuscate/ProguardTask.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/jar/obfuscate/ProguardTask.kt
@@ -144,6 +144,7 @@ abstract class ProguardTask
 
             appendProguardArgs("-whyareyoukeeping", "class io.specmatic.** { *; }")
             appendProguardArgs("-keepattributes", "!LocalVariableTable, !LocalVariableTypeTable")
+            appendProguardArgs("-keepparameternames")
 
             // Keep all public members in the internal package
             appendProguardArgs("-keep", "class !**.internal.** { public <fields>; public <methods>;}")


### PR DESCRIPTION
- **fix(obfuscation): don't obfuscate enums, jpa and spring beans**
- **fix: keep method parameter names by default**
