### PR TITLE
Skip internal project dependencies when validating snapshot dependencies

### DIFF
--- a/plugin/src/functionalTest/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesFunctionalTest.kt
@@ -1,0 +1,119 @@
+package io.specmatic.gradle.release
+
+import io.specmatic.gradle.AbstractFunctionalTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ValidateSnapshotDependenciesFunctionalTest : AbstractFunctionalTest() {
+    override fun projectVersion(): String = "2.3.4-SNAPSHOT"
+
+    private fun writeSingleProjectBuild(dependenciesBlock: String) {
+        buildFile.writeText(
+            """
+            plugins {
+                id("java")
+                id("io.specmatic.gradle")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                $dependenciesBlock
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `succeeds when all dependencies are released versions`() {
+        gradleProperties.writeText(
+            """
+            version=1.0.0
+            group=io.specmatic.example
+            """.trimIndent(),
+        )
+        writeSingleProjectBuild("""implementation("io.specmatic.example:released-lib:1.0.0")""")
+
+        val result = runWithSuccess("validateSnapshotDependencies")
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        assertThat(result.output).contains("No SNAPSHOT dependencies found.")
+    }
+
+    @Test
+    fun `fails when an external snapshot dependency is present`() {
+        writeSingleProjectBuild("""implementation("io.specmatic.example:snapshot-lib:1.0.0-SNAPSHOT")""")
+
+        val result = runWithFailure("validateSnapshotDependencies")
+
+        assertThat(result.output).contains("dependencies with SNAPSHOT versions")
+        assertThat(result.output).contains("io.specmatic.example:snapshot-lib:1.0.0-SNAPSHOT")
+        assertThat(result.output).contains("Please remove them before creating a release")
+    }
+
+    @Test
+    fun `warns instead of failing when allowSnapshotDependencies is true`() {
+        writeSingleProjectBuild("""implementation("io.specmatic.example:snapshot-lib:1.0.0-SNAPSHOT")""")
+
+        val result = runWithSuccess("validateSnapshotDependencies", "-PallowSnapshotDependencies=true")
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        assertThat(result.output).contains("dependencies with SNAPSHOT versions")
+        assertThat(result.output).contains("io.specmatic.example:snapshot-lib:1.0.0-SNAPSHOT")
+    }
+
+    @Test
+    fun `validateSnapshotDependencies fails on internal project dependencies while build is still SNAPSHOT`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "example-project"
+            include("lib-a")
+            include("lib-b")
+            """.trimIndent(),
+        )
+
+        projectDir.resolve("lib-a").mkdirs()
+        projectDir.resolve("lib-b").mkdirs()
+
+        buildFile.writeText(
+            """
+            plugins {
+                id("io.specmatic.gradle")
+            }
+
+            allprojects {
+                group = "io.specmatic.example"
+                version = "2.3.4-SNAPSHOT"
+            }
+
+            project(":lib-a") {
+                apply(plugin = "java")
+
+                repositories {
+                    mavenCentral()
+                }
+            }
+
+            project(":lib-b") {
+                apply(plugin = "java")
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    // No external SNAPSHOT dependencies - only an internal module dependency.
+                    "implementation"(project(":lib-a"))
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = runWithFailure("validateSnapshotDependencies")
+
+        assertThat(result.output).contains("dependencies with SNAPSHOT versions")
+        assertThat(result.output).contains("io.specmatic.example:lib-a:2.3.4-SNAPSHOT")
+    }
+}

--- a/plugin/src/functionalTest/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesFunctionalTest.kt
@@ -65,7 +65,7 @@ class ValidateSnapshotDependenciesFunctionalTest : AbstractFunctionalTest() {
     }
 
     @Test
-    fun `validateSnapshotDependencies fails on internal project dependencies while build is still SNAPSHOT`() {
+    fun `validateSnapshotDependencies passes when the only SNAPSHOT dependencies are internal project dependencies`() {
         settingsFile.writeText(
             """
             rootProject.name = "example-project"
@@ -111,9 +111,64 @@ class ValidateSnapshotDependenciesFunctionalTest : AbstractFunctionalTest() {
             """.trimIndent(),
         )
 
+        val result = runWithSuccess("validateSnapshotDependencies")
+
+        assertThat(result.output).contains("BUILD SUCCESSFUL")
+        assertThat(result.output).contains("No SNAPSHOT dependencies found.")
+        assertThat(result.output).doesNotContain("io.specmatic.example:lib-a:2.3.4-SNAPSHOT")
+    }
+
+    @Test
+    fun `validateSnapshotDependencies fails on external snapshot dependencies even when internal project dependencies are also SNAPSHOT`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "example-project"
+            include("lib-a")
+            include("lib-b")
+            """.trimIndent(),
+        )
+
+        projectDir.resolve("lib-a").mkdirs()
+        projectDir.resolve("lib-b").mkdirs()
+
+        buildFile.writeText(
+            """
+            plugins {
+                id("io.specmatic.gradle")
+            }
+
+            allprojects {
+                group = "io.specmatic.example"
+                version = "2.3.4-SNAPSHOT"
+            }
+
+            project(":lib-a") {
+                apply(plugin = "java")
+
+                repositories {
+                    mavenCentral()
+                }
+            }
+
+            project(":lib-b") {
+                apply(plugin = "java")
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    "implementation"(project(":lib-a"))
+                    "implementation"("io.specmatic.example:snapshot-lib:1.0.0-SNAPSHOT")
+                }
+            }
+            """.trimIndent(),
+        )
+
         val result = runWithFailure("validateSnapshotDependencies")
 
         assertThat(result.output).contains("dependencies with SNAPSHOT versions")
-        assertThat(result.output).contains("io.specmatic.example:lib-a:2.3.4-SNAPSHOT")
+        assertThat(result.output).contains("io.specmatic.example:snapshot-lib:1.0.0-SNAPSHOT")
+        assertThat(result.output).doesNotContain("io.specmatic.example:lib-a:2.3.4-SNAPSHOT")
     }
 }

--- a/plugin/src/main/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependencies.kt
+++ b/plugin/src/main/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependencies.kt
@@ -3,6 +3,7 @@ package io.specmatic.gradle.release
 import io.specmatic.gradle.license.pluginWarn
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.tasks.TaskAction
 
 abstract class ValidateSnapshotDependencies : DefaultTask() {
@@ -15,7 +16,7 @@ abstract class ValidateSnapshotDependencies : DefaultTask() {
             project.allprojects.associateWith { project ->
                 (project.configurations + project.buildscript.configurations).flatMap { cfg ->
                     cfg.dependencies.matching { dep ->
-                        dep.version?.contains("SNAPSHOT") == true
+                        dep !is ProjectDependency && dep.version?.contains("SNAPSHOT") == true
                     }
                 }
             }

--- a/plugin/src/test/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesTest.kt
+++ b/plugin/src/test/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesTest.kt
@@ -19,6 +19,13 @@ class ValidateSnapshotDependenciesTest {
         dependencies.add(configuration, notation)
     }
 
+    private fun Project.declareProjectDependency(dependencyProject: Project, configuration: String = "implementation") {
+        if (configurations.findByName(configuration) == null) {
+            configurations.create(configuration)
+        }
+        dependencies.add(configuration, dependencyProject)
+    }
+
     private fun ValidateSnapshotDependencies.assertFailsWithMessage(expectedMessage: String) {
         val thrown = catchThrowable { assertNoSnapshotDependencies() }
         assertThat(thrown).isInstanceOf(GradleException::class.java)
@@ -91,6 +98,37 @@ class ValidateSnapshotDependenciesTest {
 
             Project $subProject uses dependencies with SNAPSHOT versions:
             - io.specmatic.example:child-lib:1.0.0-SNAPSHOT
+            Please remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `ignores snapshot internal project dependencies`() {
+        val rootProject = ProjectBuilder.builder().withName("root").build()
+        val subProject = ProjectBuilder.builder().withName("child").withParent(rootProject).build()
+        subProject.version = "1.0.0-SNAPSHOT"
+        rootProject.declareProjectDependency(subProject)
+        val task = rootProject.validateSnapshotDependenciesTask()
+
+        assertThatCode { task.assertNoSnapshotDependencies() }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `ignores snapshot project dependencies but still fails on external snapshot dependencies`() {
+        val rootProject = ProjectBuilder.builder().withName("root").build()
+        val subProject = ProjectBuilder.builder().withName("child").withParent(rootProject).build()
+        subProject.version = "1.0.0-SNAPSHOT"
+        rootProject.declareProjectDependency(subProject)
+        rootProject.declareDependency("io.specmatic.example:external-lib:2.0.0-SNAPSHOT")
+        val task = rootProject.validateSnapshotDependenciesTask()
+
+        task.assertFailsWithMessage(
+            """
+            The following projects have dependencies with SNAPSHOT versions:
+
+            Project $rootProject uses dependencies with SNAPSHOT versions:
+            - io.specmatic.example:external-lib:2.0.0-SNAPSHOT
             Please remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.
             """.trimIndent(),
         )

--- a/plugin/src/test/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesTest.kt
+++ b/plugin/src/test/kotlin/io/specmatic/gradle/release/ValidateSnapshotDependenciesTest.kt
@@ -1,0 +1,120 @@
+package io.specmatic.gradle.release
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.catchThrowable
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+class ValidateSnapshotDependenciesTest {
+    private fun Project.validateSnapshotDependenciesTask(): ValidateSnapshotDependencies =
+        tasks.register("validateSnapshotDependencies", ValidateSnapshotDependencies::class.java).get()
+
+    private fun Project.declareDependency(notation: String, configuration: String = "implementation") {
+        if (configurations.findByName(configuration) == null) {
+            configurations.create(configuration)
+        }
+        dependencies.add(configuration, notation)
+    }
+
+    private fun ValidateSnapshotDependencies.assertFailsWithMessage(expectedMessage: String) {
+        val thrown = catchThrowable { assertNoSnapshotDependencies() }
+        assertThat(thrown).isInstanceOf(GradleException::class.java)
+        assertThat(thrown.message).isEqualToNormalizingNewlines(expectedMessage)
+    }
+
+    @Test
+    fun `succeeds when there are no snapshot dependencies`() {
+        val project = ProjectBuilder.builder().build()
+        project.declareDependency("io.specmatic.example:lib:1.0.0")
+        val task = project.validateSnapshotDependenciesTask()
+
+        assertThatCode { task.assertNoSnapshotDependencies() }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `fails when a configuration has an external snapshot dependency`() {
+        val project = ProjectBuilder.builder().build()
+        project.declareDependency("io.specmatic.example:lib:1.0.0-SNAPSHOT")
+        val task = project.validateSnapshotDependenciesTask()
+
+        task.assertFailsWithMessage(
+            """
+            The following projects have dependencies with SNAPSHOT versions:
+
+            Project $project uses dependencies with SNAPSHOT versions:
+            - io.specmatic.example:lib:1.0.0-SNAPSHOT
+            Please remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `fails when a buildscript classpath dependency is a snapshot`() {
+        val project = ProjectBuilder.builder().build()
+        project.buildscript.dependencies.add("classpath", "io.specmatic.example:some-plugin:1.0.0-SNAPSHOT")
+        val task = project.validateSnapshotDependenciesTask()
+
+        task.assertFailsWithMessage(
+            """
+            The following projects have dependencies with SNAPSHOT versions:
+
+            Project $project uses dependencies with SNAPSHOT versions:
+            - io.specmatic.example:some-plugin:1.0.0-SNAPSHOT
+            Please remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `warns instead of failing when allowSnapshotDependencies is true`() {
+        val project = ProjectBuilder.builder().build()
+        project.extensions.extraProperties.set("allowSnapshotDependencies", "true")
+        project.declareDependency("io.specmatic.example:lib:1.0.0-SNAPSHOT")
+        val task = project.validateSnapshotDependenciesTask()
+
+        assertThatCode { task.assertNoSnapshotDependencies() }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `detects snapshot dependencies declared in a subproject`() {
+        val rootProject = ProjectBuilder.builder().withName("root").build()
+        val subProject = ProjectBuilder.builder().withName("child").withParent(rootProject).build()
+        subProject.declareDependency("io.specmatic.example:child-lib:1.0.0-SNAPSHOT")
+        val task = rootProject.validateSnapshotDependenciesTask()
+
+        task.assertFailsWithMessage(
+            """
+            The following projects have dependencies with SNAPSHOT versions:
+
+            Project $subProject uses dependencies with SNAPSHOT versions:
+            - io.specmatic.example:child-lib:1.0.0-SNAPSHOT
+            Please remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `groups snapshot dependencies by project in the failure message`() {
+        val rootProject = ProjectBuilder.builder().withName("root").build()
+        rootProject.declareDependency("io.specmatic.example:root-lib:1.0.0-SNAPSHOT")
+        val subProject = ProjectBuilder.builder().withName("child").withParent(rootProject).build()
+        subProject.declareDependency("io.specmatic.example:child-lib:2.0.0-SNAPSHOT")
+        val task = rootProject.validateSnapshotDependenciesTask()
+
+        task.assertFailsWithMessage(
+            """
+            The following projects have dependencies with SNAPSHOT versions:
+
+            Project $rootProject uses dependencies with SNAPSHOT versions:
+            - io.specmatic.example:root-lib:1.0.0-SNAPSHOT
+
+            Project $subProject uses dependencies with SNAPSHOT versions:
+            - io.specmatic.example:child-lib:2.0.0-SNAPSHOT
+            Please remove them before creating a release. Run with `-PallowSnapshotDependencies=true` to disable.
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
In task `validateSnapshotDependencies` we now skip internal project dependencies that may be snapshot because our release process requires that internal deps may be snapshot but any external deps must not be snapshot.

For example for enterprise, the internal gradle projects will all be at snapshot but core, reporter etc. must not be snapshot.